### PR TITLE
Fix for VortiK deep core mining crash

### DIFF
--- a/control.lua
+++ b/control.lua
@@ -194,7 +194,8 @@ function createLabelForResourcePatch(player, surface, patch)
         local label = ""
         if global.settings["resource-labels-show-resource-count"] then
             --show yield only for non fluid infinite ores
-            if isInfiniteResource(entity) and ResourceConfig[entity.name].type ~= "fluid" then
+            local resourceConf = ResourceConfig[entity.name]
+            if isInfiniteResource(entity) and resourceConf and resourceConf.type ~= "fluid" then
                 label = label .. getResourceCount(patch) .. "% "
             else
                 if getLabel(entity):find("Rock") then


### PR DESCRIPTION
Depleted chunks that get added don't have a resource config crashing label generation